### PR TITLE
chore: templates that inherits base can now set its own head tags

### DIFF
--- a/number_generator/templates/number_generator/about.html
+++ b/number_generator/templates/number_generator/about.html
@@ -1,7 +1,9 @@
 {% extends "number_generator/base.html" %}
 
 {% load static %}
-{% block stylesheet %}{% static "number_generator/style_about.css" %}{% endblock %}
+{% block head %}
+<link rel="stylesheet" href="{% static "number_generator/style_about.css" %}" />
+{% endblock %}
 {% block title %}About - Lottery Numberz{% endblock %}
 {% block about_selected%}selected{% endblock %}
 

--- a/number_generator/templates/number_generator/base.html
+++ b/number_generator/templates/number_generator/base.html
@@ -2,6 +2,7 @@
 <html lang="en">
     <head>
         {% load static %}
+        {% block head %}{% endblock %}
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <title>{% block title %}Page Title{% endblock %}</title>

--- a/number_generator/templates/number_generator/generation_detail.html
+++ b/number_generator/templates/number_generator/generation_detail.html
@@ -1,7 +1,9 @@
 {% extends "number_generator/base.html" %}
 
 {% load static %}
-{% block stylesheet %}{% static "number_generator/style_generation_detail.css" %}{% endblock %}
+{% block head %}
+<link rel="stylesheet" href="{% static "number_generator/style_generation_detail.css" %}" />
+{% endblock %}
 {% block title %}Generation Details - Lottery Numberz{% endblock %}
 
 {% block content %}

--- a/number_generator/templates/number_generator/generation_list.html
+++ b/number_generator/templates/number_generator/generation_list.html
@@ -1,7 +1,9 @@
 {% extends "number_generator/base.html" %}
 
 {% load static %}
-{% block stylesheet %}{% static "number_generator/style_generation_list.css" %}{% endblock %}
+{% block head %}
+<link rel="stylesheet" href="{% static "number_generator/style_generation_list.css" %}" />
+{% endblock %}
 {% block title %}Generation List - Lottery Numberz{% endblock %}
 {% block generations_selected%}selected{% endblock %}
 

--- a/number_generator/templates/number_generator/home.html
+++ b/number_generator/templates/number_generator/home.html
@@ -1,7 +1,9 @@
 {% extends "number_generator/base.html" %}
 
 {% load static %}
-{% block stylesheet %}{% static "number_generator/style_home.css" %}{% endblock %}
+{% block head %}
+<link rel="stylesheet" href="{% static "number_generator/style_home.css" %}" />
+{% endblock %}
 {% block title %}Home - Lottery Numberz{% endblock %}
 {% block home_selected%}selected{% endblock %}
 


### PR DESCRIPTION
- updates the base.html to allow its childs to set tags inside head
- updates templates that inherits base.html setting their own style tag